### PR TITLE
chore: use typescript in SimpleLambdaEdge

### DIFF
--- a/lambda-assets/extensions/simple-lambda-edge/index.ts
+++ b/lambda-assets/extensions/simple-lambda-edge/index.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 const content = `
 <\!DOCTYPE html>
 <html lang="en">
@@ -8,12 +6,14 @@ const content = `
     <title>Simple Lambda@Edge Static Content Response</title>
   </head>
   <body>
-    <p>Hello from Lambda@Edge!</p>
+    <p>Hello from Lambda@Edge!!</p>
   </body>
 </html>
 `;
 
-exports.handler = (event, context, callback) => {
+export async function handler(event: any, context: any) {
+  console.log(JSON.stringify(event))
+  console.log(JSON.stringify(context))
   /*
    * Generate HTTP OK response using 200 status code with HTML body.
    */
@@ -32,5 +32,5 @@ exports.handler = (event, context, callback) => {
     },
     body: content,
   };
-  callback(null, response);
+  return response
 };

--- a/src/__tests__/__snapshots__/integ.default-dir-index.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.default-dir-index.test.ts.snap
@@ -13,28 +13,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67ArtifactHash035F1A06": Object {
-      "Description": "Artifact hash for asset \\"05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67\\"",
+    "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aArtifactHash375B461C": Object {
+      "Description": "Artifact hash for asset \\"1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0a\\"",
       "Type": "String",
     },
-    "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67S3Bucket5B487BF3": Object {
-      "Description": "S3 bucket for asset \\"05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67\\"",
+    "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aS3BucketD78D790B": Object {
+      "Description": "S3 bucket for asset \\"1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0a\\"",
       "Type": "String",
     },
-    "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67S3VersionKeyE68588F1": Object {
-      "Description": "S3 key for asset version \\"05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67\\"",
-      "Type": "String",
-    },
-    "AssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43ArtifactHash37C48A15": Object {
-      "Description": "Artifact hash for asset \\"37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43\\"",
-      "Type": "String",
-    },
-    "AssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3BucketF477E454": Object {
-      "Description": "S3 bucket for asset \\"37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43\\"",
-      "Type": "String",
-    },
-    "AssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3VersionKeyD13218C8": Object {
-      "Description": "S3 key for asset version \\"37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43\\"",
+    "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aS3VersionKeyF687558E": Object {
+      "Description": "S3 key for asset version \\"1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0a\\"",
       "Type": "String",
     },
     "AssetParameters4cd61014b71160e8c66fe167e43710d5ba068b80b134e9bd84508cf9238b2392ArtifactHashE56CD69A": Object {
@@ -59,6 +47,18 @@ Object {
     },
     "AssetParameters9ef8e2525226a20bd78b524c9b4dd54f693d614f1ae1efc8a674f3bbe6b90342S3VersionKey085FBD5E": Object {
       "Description": "S3 key for asset version \\"9ef8e2525226a20bd78b524c9b4dd54f693d614f1ae1efc8a674f3bbe6b90342\\"",
+      "Type": "String",
+    },
+    "AssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cArtifactHash239124F1": Object {
+      "Description": "Artifact hash for asset \\"a48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554c\\"",
+      "Type": "String",
+    },
+    "AssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3Bucket5C267C63": Object {
+      "Description": "S3 bucket for asset \\"a48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554c\\"",
+      "Type": "String",
+    },
+    "AssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3VersionKey95F977B3": Object {
+      "Description": "S3 key for asset version \\"a48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554c\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -165,12 +165,6 @@ Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "Parameters": Object {
-          "referencetodemostackAssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3BucketC94868AERef": Object {
-            "Ref": "AssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3BucketF477E454",
-          },
-          "referencetodemostackAssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3VersionKey88B3E78FRef": Object {
-            "Ref": "AssetParameters37e3075aaf34134c28ec6fc3707a9b7b71883011866fbd41e511a35a3b888e43S3VersionKeyD13218C8",
-          },
           "referencetodemostackAssetParameters4cd61014b71160e8c66fe167e43710d5ba068b80b134e9bd84508cf9238b2392S3BucketBF1D8B9CRef": Object {
             "Ref": "AssetParameters4cd61014b71160e8c66fe167e43710d5ba068b80b134e9bd84508cf9238b2392S3BucketBF7A7F3F",
           },
@@ -182,6 +176,12 @@ Object {
           },
           "referencetodemostackAssetParameters9ef8e2525226a20bd78b524c9b4dd54f693d614f1ae1efc8a674f3bbe6b90342S3VersionKey4AF705ACRef": Object {
             "Ref": "AssetParameters9ef8e2525226a20bd78b524c9b4dd54f693d614f1ae1efc8a674f3bbe6b90342S3VersionKey085FBD5E",
+          },
+          "referencetodemostackAssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3Bucket15CE9564Ref": Object {
+            "Ref": "AssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3Bucket5C267C63",
+          },
+          "referencetodemostackAssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3VersionKeyB006533DRef": Object {
+            "Ref": "AssetParametersa48da8f58520a9e882c296b7c95c324adf8086d779e5b63e218da1211ac4554cS3VersionKey95F977B3",
           },
           "referencetodemostackAssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3Bucket24CC697DRef": Object {
             "Ref": "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3Bucket55EFA30C",
@@ -210,7 +210,7 @@ Object {
               },
               "/",
               Object {
-                "Ref": "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67S3Bucket5B487BF3",
+                "Ref": "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aS3BucketD78D790B",
               },
               "/",
               Object {
@@ -220,7 +220,7 @@ Object {
                     "Fn::Split": Array [
                       "||",
                       Object {
-                        "Ref": "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67S3VersionKeyE68588F1",
+                        "Ref": "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aS3VersionKeyF687558E",
                       },
                     ],
                   },
@@ -233,7 +233,7 @@ Object {
                     "Fn::Split": Array [
                       "||",
                       Object {
-                        "Ref": "AssetParameters05eb5c739b830772d51a13cfc711a99cf599778ee70cf5e3d8f9746e9af9ed67S3VersionKeyE68588F1",
+                        "Ref": "AssetParameters1ac7bc7d35544f60a65ea80300f9b794a9e4f89fc3f61864d2b41b345b53dc0aS3VersionKeyF687558E",
                       },
                     ],
                   },

--- a/src/__tests__/__snapshots__/integ.simgple-lambda-edge.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.simgple-lambda-edge.test.ts.snap
@@ -13,16 +13,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbArtifactHashD361E484": Object {
-      "Description": "Artifact hash for asset \\"c71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bb\\"",
+    "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657ArtifactHash861A9185": Object {
+      "Description": "Artifact hash for asset \\"94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657\\"",
       "Type": "String",
     },
-    "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbS3Bucket7F099326": Object {
-      "Description": "S3 bucket for asset \\"c71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bb\\"",
+    "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657S3Bucket958253AA": Object {
+      "Description": "S3 bucket for asset \\"94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657\\"",
       "Type": "String",
     },
-    "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbS3VersionKey17C22D79": Object {
-      "Description": "S3 key for asset version \\"c71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bb\\"",
+    "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657S3VersionKey863C7BC1": Object {
+      "Description": "S3 key for asset version \\"94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657\\"",
       "Type": "String",
     },
     "AssetParametersfa5e260d50fc855dc6f3a16e3ebdd379cfa7b3248af9e5848bb19df7c74d8a4bArtifactHash3AF93366": Object {
@@ -46,7 +46,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbS3Bucket7F099326",
+            "Ref": "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657S3Bucket958253AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -59,7 +59,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbS3VersionKey17C22D79",
+                          "Ref": "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657S3VersionKey863C7BC1",
                         },
                       ],
                     },
@@ -72,7 +72,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc71639d79986e9921728120c1159cf455e9cbe92495805a55dc22f07d9bd82bbS3VersionKey17C22D79",
+                          "Ref": "AssetParameters94818dfc9cdc0962ce85f27a5b457ffaa5a876a606726a700124b860a170b657S3VersionKey863C7BC1",
                         },
                       ],
                     },
@@ -93,7 +93,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "SimpleLambdaEdgeFuncCurrentVersionC9DD846A68e77f21cb1477592d4d9684d6b07efd": Object {
+    "SimpleLambdaEdgeFuncCurrentVersionC9DD846A3a2ed6f14fe43d702350aa0ccb398f83": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "SimpleLambdaEdgeFunc4E03AF0C",
@@ -202,7 +202,7 @@ Object {
               Object {
                 "EventType": "viewer-request",
                 "LambdaFunctionARN": Object {
-                  "Ref": "SimpleLambdaEdgeFuncCurrentVersionC9DD846A68e77f21cb1477592d4d9684d6b07efd",
+                  "Ref": "SimpleLambdaEdgeFuncCurrentVersionC9DD846A3a2ed6f14fe43d702350aa0ccb398f83",
                 },
               },
             ],

--- a/src/__tests__/integ.simgple-lambda-edge.test.ts
+++ b/src/__tests__/integ.simgple-lambda-edge.test.ts
@@ -37,7 +37,7 @@ test('minimal usage', () => {
           {
             EventType: 'viewer-request',
             LambdaFunctionARN: {
-              Ref: 'SimpleLambdaEdgeFuncCurrentVersionC9DD846A68e77f21cb1477592d4d9684d6b07efd',
+              Ref: 'SimpleLambdaEdgeFuncCurrentVersionC9DD846A3a2ed6f14fe43d702350aa0ccb398f83',
             },
           },
         ],


### PR DESCRIPTION
1. `SimpleLambdaEdge` now uses TypeScript instead of JavaScript
2. will print `event` and `context` in the cloudwatch logs