### PR TITLE
chore: cache control for http302 from origin

### DIFF
--- a/lambda-assets/extensions/cf-http302-from-origin/index.ts
+++ b/lambda-assets/extensions/cf-http302-from-origin/index.ts
@@ -1,10 +1,9 @@
-import { String } from 'aws-sdk/clients/cloudsearch';
 import axios, { AxiosResponse } from 'axios';
 
 export interface HttpResponse {
   readonly status: number;
   readonly statusDescription: string;
-  readonly headers: { [key: string]: {[key: string]: String}[] },
+  readonly headers: { [key: string]: {[key: string]: string}[] },
   readonly body: string,
 }
 
@@ -21,30 +20,29 @@ export async function handler(event: any) {
     const locationUrl = response.headers['location'][0].value;
     const newResponse = await HttpGet(locationUrl)
     const responseObject: HttpResponse = {
-      headers: {
-        'cache-control': [{
-          key: 'Cache-Control',
-          value: `max-age=0`,
-        }],
-      },
+      headers: {},
       status: newResponse.status,
       statusDescription: newResponse.statusText,
       body: newResponse.data,
     }
-    return responseObject
+    return cacheControl(responseObject, '10')
   } else {
     return response;
   }
 };
 
-
-function cacheControl(responseObject: HttpResponse,  maxAge: string) {
-  return Object.assign(responseObject, {
-    headers: {
-      'cache-control': [{
-        key: 'Cache-Control',
-        value: `max-age=${maxAge}`,
-      }],
+/**
+ * set the cache control header
+ * @param responseObject 
+ * @param maxAge 
+ * @returns 
+ */
+function cacheControl(responseObject: HttpResponse,  maxAge: string): HttpResponse {
+  responseObject['headers']['cache-control'] = [
+    {
+      key: 'Cache-Control',
+      value: `max-age=${maxAge}`,
     }
-  })
+  ]
+  return responseObject
 }

--- a/src/__tests__/__snapshots__/integ.http302-from-origin.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.http302-from-origin.test.ts.snap
@@ -3,6 +3,18 @@
 exports[`basic minimal setting 1`] = `
 Object {
   "Parameters": Object {
+    "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9ArtifactHash9D55CCD4": Object {
+      "Description": "Artifact hash for asset \\"2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9\\"",
+      "Type": "String",
+    },
+    "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9S3Bucket6BADCD39": Object {
+      "Description": "S3 bucket for asset \\"2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9\\"",
+      "Type": "String",
+    },
+    "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9S3VersionKey9FB74CAC": Object {
+      "Description": "S3 key for asset version \\"2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9\\"",
+      "Type": "String",
+    },
     "AssetParameters90d553a62b70bc897a968de82edcb8734c9635d27a03fc94687ef12bef93bb17ArtifactHash166F4C6F": Object {
       "Description": "Artifact hash for asset \\"90d553a62b70bc897a968de82edcb8734c9635d27a03fc94687ef12bef93bb17\\"",
       "Type": "String",
@@ -15,21 +27,9 @@ Object {
       "Description": "S3 key for asset version \\"90d553a62b70bc897a968de82edcb8734c9635d27a03fc94687ef12bef93bb17\\"",
       "Type": "String",
     },
-    "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aArtifactHash5A556600": Object {
-      "Description": "Artifact hash for asset \\"9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9a\\"",
-      "Type": "String",
-    },
-    "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aS3BucketA74C34AE": Object {
-      "Description": "S3 bucket for asset \\"9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9a\\"",
-      "Type": "String",
-    },
-    "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aS3VersionKeyF58998F8": Object {
-      "Description": "S3 key for asset version \\"9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9a\\"",
-      "Type": "String",
-    },
   },
   "Resources": Object {
-    "HTTP302FromOriginFuncCurrentVersionD9CC98DE3a7d80ddb7d15bf1a16e1b9ada5ed143": Object {
+    "HTTP302FromOriginFuncCurrentVersionD9CC98DE2dfbb9579407f471b6c5b04c85e3f3a9": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "HTTP302FromOriginFuncFCF29B3D",
@@ -44,7 +44,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aS3BucketA74C34AE",
+            "Ref": "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9S3Bucket6BADCD39",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -57,7 +57,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aS3VersionKeyF58998F8",
+                          "Ref": "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9S3VersionKey9FB74CAC",
                         },
                       ],
                     },
@@ -70,7 +70,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9605a2452c63a7be4282f8171b34163c260984550c4fae0b7b3440e1bec06f9aS3VersionKeyF58998F8",
+                          "Ref": "AssetParameters2df29467db4859aa7f6cd63e923436ab203e39ab01b2890f494cdaa0a2d997f9S3VersionKey9FB74CAC",
                         },
                       ],
                     },
@@ -287,7 +287,7 @@ def handler(event, context):
                 "EventType": "origin-response",
                 "IncludeBody": false,
                 "LambdaFunctionARN": Object {
-                  "Ref": "HTTP302FromOriginFuncCurrentVersionD9CC98DE3a7d80ddb7d15bf1a16e1b9ada5ed143",
+                  "Ref": "HTTP302FromOriginFuncCurrentVersionD9CC98DE2dfbb9579407f471b6c5b04c85e3f3a9",
                 },
               },
             ],

--- a/src/demo/http302-from-origin/index.ts
+++ b/src/demo/http302-from-origin/index.ts
@@ -47,7 +47,7 @@ const backend = new Http302Backend(stack, 'Http302Backend');
 const dist = new cf.Distribution(stack, 'dist', {
   defaultBehavior: {
     origin: new origins.HttpOrigin(backend.domainName),
-    cachePolicy: cf.CachePolicy.CACHING_DISABLED,
+    cachePolicy: cf.CachePolicy.CACHING_OPTIMIZED,
     edgeLambdas: [ext],
   },
 });


### PR DESCRIPTION
1. cache control from the L@E function(default: 10s)
2. enable the `caching optimized` cache policy